### PR TITLE
Fix clicking on buttons on error pop-up doesn't work (#1250942)

### DIFF
--- a/meh/ui/gui.py
+++ b/meh/ui/gui.py
@@ -113,11 +113,16 @@ class MainExceptionWindow(AbstractMainExceptionWindow):
 
     def run(self, *args, **kwargs):
         self._main_window.show_all()
+        # keep our window above dialogs
+        self._main_window.set_modal(True)
+        self._main_window.set_keep_above(True)
         Gtk.main()
         self.destroy()
         return self._response
 
     def on_report_clicked(self, button):
+        # hide our window to not interfere with libreport window
+        self._main_window.hide()
         self._response = MAIN_RESPONSE_SAVE
         Gtk.main_quit()
 


### PR DESCRIPTION
Set python-meh window to be modal and above other windows and hide
it when libreport window is displayed.

(Without hiding python-meh window would be displayed over the libreport window. Setting keep_above/model to False in on_report_clicked doesn't help.)
