### PR TITLE
Set translations domain for glade files

### DIFF
--- a/meh/ui/gui.py
+++ b/meh/ui/gui.py
@@ -81,6 +81,7 @@ class MainExceptionWindow(AbstractMainExceptionWindow):
                                              *args, **kwargs)
 
         builder = Gtk.Builder()
+        builder.set_translation_domain("python-meh")
         glade_file = find_glade_file("exception-dialog.glade")
         builder.add_from_file(glade_file)
         builder.connect_signals(self)


### PR DESCRIPTION
Without the `set_translation_domain` strings from Glade files are not translated.
