### PR TITLE
Remove build requires for pocketlint

### DIFF
--- a/python-meh.spec
+++ b/python-meh.spec
@@ -36,7 +36,6 @@ BuildRequires: python3-setuptools
 BuildRequires: python3-dbus
 BuildRequires: libreport-python3 >= %{libreportver}
 BuildRequires: python3-six
-BuildRequires: python3-pocketlint
 %endif
 
 Requires: python


### PR DESCRIPTION
Listing python3-pocketlint as a BuildRequires is
redundant as it is used during the rpm build.
