### PR TITLE
Gtk: Add gi.require_version to specify the version of Gtk (#1437381)

### DIFF
--- a/meh/ui/gui.py
+++ b/meh/ui/gui.py
@@ -20,6 +20,10 @@ from meh import *
 from meh.ui import *
 import os
 import report
+
+import gi
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gtk
 
 import gettext


### PR DESCRIPTION
Gtk was imported without specifying a version first. Use
gi.require_version before import to ensure that the right
version gets loaded.

Resolves: rhbz#1437381