### PR TITLE
Drop Python 2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ TAG=$(PKGNAME)-$(VERSION)
 
 PREFIX=/usr
 
-PYTHON2=python2
-PYTHON3=python3
-PYTHON=$(PYTHON2)
+PYTHON=python3
 
 TESTSUITE:=tests/baseclass.py
 
@@ -27,11 +25,8 @@ clean:
 	$(PYTHON) setup.py -q clean --all
 
 test:
-	@echo "*** Running unittests with Python 2 ***"
-	PYTHONPATH=. $(PYTHON2) $(TESTSUITE) -v
-
 	@echo "*** Running unittests with Python 3 ***"
-	PYTHONPATH=. $(PYTHON3) $(TESTSUITE) -v
+	PYTHONPATH=. $(PYTHON) $(TESTSUITE) -v
 
 check:
 	PYTHONPATH=. tests/pylint/runpylint.py

--- a/meh/dump.py
+++ b/meh/dump.py
@@ -28,8 +28,6 @@ import inspect
 import os
 import traceback
 import sys
-import codecs
-import six
 from meh import PackageInfo
 from meh.safe_string import SafeStr
 
@@ -479,16 +477,10 @@ class ExceptionDump(object):
         # And finally, write a bunch of files into the dump too.
         for fname in self.conf.fileList:
             try:
-                if six.PY2:
-                    with codecs.open(fname, "r", "utf-8", "ignore") as fobj:
-                        ret += "\n\n%s:\n" % (fname,)
-                        for line in fobj:
-                            ret += line.encode("utf-8")
-                else:
-                    with open(fname, "rt", encoding="utf-8") as fobj:
-                        ret += "\n\n%s:\n" % (fname,)
-                        for line in fobj:
-                            ret += line
+                with open(fname, "rt", encoding="utf-8") as fobj:
+                    ret += "\n\n%s:\n" % (fname,)
+                    for line in fobj:
+                        ret += line
             except IOError:
                 pass
             except:

--- a/meh/ui/__init__.py
+++ b/meh/ui/__init__.py
@@ -65,7 +65,7 @@ class AbstractIntf(object):
         """
         raise NotImplementedError
 
-    def saveExceptionWindow(self, exnFile, *args, **kwargs):
+    def saveExceptionWindow(self, signature, *args, **kwargs):
         """Create and return an instance of the exception saving dialog.  This
            method must be provided by all subclasses.
         """

--- a/python-meh.spec
+++ b/python-meh.spec
@@ -1,7 +1,4 @@
-%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
-%global with_python3 1
-
-%define libreportver 2.0.18-1
+%global libreportver 2.0.18-1
 
 Summary:  A python library for handling exceptions
 Name: python-meh
@@ -17,58 +14,33 @@ Release: 1%{?dist}
 Source0: https://github.com/rhinstaller/python-meh/archive/%{name}-%{version}.tar.gz
 
 License: GPLv2+
-Group: System Environment/Libraries
 BuildArch: noarch
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildRequires: python-devel
 BuildRequires: gettext
-BuildRequires: python-setuptools
 BuildRequires: intltool
-BuildRequires: dbus-python
 BuildRequires: libreport-gtk >= %{libreportver}
 BuildRequires: libreport-cli >= %{libreportver}
-BuildRequires: libreport-python >= %{libreportver}
-BuildRequires: python-six
 
-%if 0%{with_python3}
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python3-dbus
-BuildRequires: libreport-python3 >= %{libreportver}
-BuildRequires: python3-six
-BuildRequires: python3-pocketlint
-%endif
+BuildRequires: python3-libreport >= %{libreportver}
 
-Requires: python
-Requires: dbus-python
-Requires: rpm-python
-Requires: libreport-cli >= %{libreportver}
-Requires: libreport-python >= %{libreportver}
-Requires: python-six
-
-%description
-The python-meh package is a python library for handling, saving, and reporting
+%global _description\
+The python-meh package is a python library for handling, saving, and reporting \
 exceptions.
 
-%package gui
-Summary: Graphical user interface for the python-meh library
-Requires: python-meh = %{version}-%{release}
-Requires: pygobject3
-Requires: gtk3
-Requires: libreport-gtk >= %{libreportver}
+%description %_description
 
-%description gui
-The python-meh-gui package provides a GUI for the python-meh library.
-
-%if 0%{with_python3}
 %package -n python3-meh
 Summary:  A python 3 library for handling exceptions
+%{?python_provide:%python_provide python3-meh}
+Obsoletes: python-meh < 0.46-1
+Obsoletes: python2-meh < 0.46-1
 Requires: python3
 Requires: python3-dbus
-Requires: rpm-python3
+Requires: python3-rpm
 Requires: libreport-cli >= %{libreportver}
-Requires: libreport-python3 >= %{libreportver}
-Requires: python3-six
+Requires: python3-libreport >= %{libreportver}
 
 %description -n python3-meh
 The python3-meh package is a python 3 library for handling, saving, and reporting
@@ -76,6 +48,9 @@ exceptions.
 
 %package -n python3-meh-gui
 Summary: Graphical user interface for the python3-meh library
+%{?python_provide:%python_provide python3-meh-gui}
+Obsoletes: python-meh-gui < 0.46-1
+Obsoletes: python2-meh-gui < 0.46-1
 Requires: python3-meh = %{version}-%{release}
 Requires: python3-gobject, gtk3
 Requires: libreport-gtk >= %{libreportver}
@@ -83,67 +58,27 @@ Requires: libreport-gtk >= %{libreportver}
 %description -n python3-meh-gui
 The python3-meh-gui package provides a GUI for the python3-meh library.
 
-%endif
-
 %prep
 %setup -q
-
-%if 0%{?with_python3}
-rm -rf %{py3dir}
-cp -a . %{py3dir}
-%endif # with_python3
 
 %build
 make
 
-%if 0%{?with_python3}
-pushd %{py3dir}
-make PYTHON=%{__python3}
-popd
-%endif
-
 %check
 make test
 
-%if 0%{?with_python3}
-pushd %{py3dir}
-# Needs UTF-8 locale
-LANG=en_US.UTF-8 make PYTHON=%{__python3} test
-popd
-%endif
-
 %install
-rm -rf %{buildroot}
 make DESTDIR=%{buildroot} install
-
-%if 0%{?with_python3}
-pushd %{py3dir}
-make PYTHON=%{__python3} DESTDIR=%{buildroot} install
-popd
-%endif
 
 %find_lang %{name}
 
-%clean
-rm -rf %{buildroot}
-
-%files -f %{name}.lang
-%defattr(-,root,root,-)
-%doc ChangeLog COPYING
-%{python_sitelib}/*
-%exclude %{python_sitelib}/meh/ui/gui.py*
-
-%files gui
-%{python_sitelib}/meh/ui/gui.py*
-%{_datadir}/python-meh
-
-%files -n python3-meh
+%files -n python3-meh -f %{name}.lang
 %doc ChangeLog COPYING
 %{python3_sitelib}/*
-%exclude %{python3_sitelib}/meh/ui/gui.py*
+%exclude %{python3_sitelib}/meh/ui/
 
 %files -n python3-meh-gui
-%{python3_sitelib}/meh/ui/gui.py*
+%{python3_sitelib}/meh/ui/
 %{_datadir}/python-meh
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 from distutils.core import setup
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -4,7 +4,6 @@ import os
 import sys
 import tempfile
 import unittest
-import six
 
 from meh import ExceptionInfo
 from meh.dump import ExceptionDump
@@ -20,10 +19,7 @@ class BaseTestCase(unittest.TestCase):
     def openFile(self, mode="w"):
         (fd, path) = tempfile.mkstemp()
         # only Python 3 has supports the "encoding" keyword argument
-        if six.PY2:
-            fo = os.fdopen(fd, mode)
-        else:
-            fo = os.fdopen(fd, mode, encoding="utf-8")
+        fo = os.fdopen(fd, mode, encoding="utf-8")
 
         return (fo, path)
 

--- a/tests/handle_binary.py
+++ b/tests/handle_binary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from tests.baseclass import BaseTestCase
 from meh import Config
 

--- a/tests/handle_unicode.py
+++ b/tests/handle_unicode.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-import six
-
 from tests.baseclass import BaseTestCase
 from meh import Config
 
@@ -19,10 +16,7 @@ class UnicodeExample(object):
 class HandleUnicode_TestCase(BaseTestCase):
     def setUp(self):
         # write UTF-8 and ASCII files for testing
-        if six.PY2:
-            (fobj, self.uni_file_path) = self.openFile()
-        else:
-            (fobj, self.uni_file_path) = self.openFile(mode="wt")
+        (fobj, self.uni_file_path) = self.openFile(mode="wt")
         try:
             fobj.write(UNICODE_LINE)
         except UnicodeEncodeError:
@@ -45,10 +39,7 @@ class HandleUnicode_TestCase(BaseTestCase):
 
         self.assertIn("_str: " + str(UNICODE_STR.encode("utf-8")), dump)
         self.assertIn("encoded_str: " + str(UNICODE_STR.encode("utf-8")), dump)
-        if six.PY2:
-            self.assertIn(str(UNICODE_LINE.encode("utf-8")), dump)
-        else:
-            self.assertIn(UNICODE_LINE, dump)
+        self.assertIn(UNICODE_LINE, dump)
 
         self.assertIn("ascii_str: " + ASCII_STR, dump)
         self.assertIn(ASCII_LINE.rstrip(), dump)


### PR DESCRIPTION
No one is apparently using the python2 subpackages and the end of
upstream support for Python 2 is in sight, so drop the python2
subpackages and Python 2 support in the codebase.

Dropping Python 2 support is pretty trivial and basically amounts
to stop using six and fixing the few places where it is used.