### PR TITLE
Make sure gettext returns strings not bytes

### DIFF
--- a/meh/handler.py
+++ b/meh/handler.py
@@ -25,7 +25,7 @@ import traceback
 import subprocess
 
 import gettext
-_ = lambda x: gettext.ldgettext("python-meh", x)
+_ = lambda x: gettext.translation("python-meh", fallback=True).gettext(x) if x != "" else ""
 
 class NoNetwork(Exception):
     def __init__(self, msg=""):

--- a/meh/ui/gui.py
+++ b/meh/ui/gui.py
@@ -28,7 +28,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 import gettext
-_ = lambda x: gettext.ldgettext("python-meh", x)
+_ = lambda x: gettext.translation("python-meh", fallback=True).gettext(x) if x != "" else ""
 
 def find_glade_file(file):
     path = os.environ.get("GLADEPATH", "./:ui/:/tmp/updates/:/tmp/updates/ui/:/usr/share/python-meh/")

--- a/meh/ui/text.py
+++ b/meh/ui/text.py
@@ -33,7 +33,7 @@ else:
     raw_input_fn = raw_input    # pylint: disable=undefined-variable
 
 import gettext
-_ = lambda x: gettext.ldgettext("python-meh", x)
+_ = lambda x: gettext.translation("python-meh", fallback=True).gettext(x) if x != "" else ""
 
 
 class IOHandler(object):


### PR DESCRIPTION
Looks like this behavior changed in Python 3 & ldgettext() started to
return bytes.

So use gettext.translation() instead, like we did in Anaconda.
This should be the "right" way for Python 3 & properly return strings.