### PR TITLE
Rename Zanata branch to rhel-8 (#1723885)

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -2,6 +2,6 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://fedora.zanata.org/</url>
   <project>python-meh</project>
-  <project-version>rhel-devel</project-version>
+  <project-version>rhel-8</project-version>
   <project-type>gettext</project-type>
 </config>


### PR DESCRIPTION
The branch name should be consistent with Anaconda,
which also uses branch named "rhel-8" on Zanata.

Resolves: rhbz#1723885