### PR TITLE
Fix make archive command after pot file removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ archive: po-pull
 	tar -rf $(PKGNAME)-$(VERSION).tar $(PKGNAME)-$(VERSION)
 	gzip -9 $(PKGNAME)-$(VERSION).tar
 	rm -rf $(PKGNAME)-$(VERSION)
-	git checkout -- po/$(PKGNAME).pot
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 local: po-pull


### PR DESCRIPTION
Pot file was moved to a separate repository, however, this command wasn't changed appropriately. Fix this now.