### PR TITLE
setup.py: switch from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='python-meh',
       version='0.50',


### PR DESCRIPTION
In Python 3.10 'distutils' is deprecated with removal slated for Python
3.12. Switch from 'distutils.core' to 'setuptools'.

This also allows for a 'wheel' binary archive format to be built with
'setup.py bdist_wheel'.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>