### PR TITLE
Make libreport optional

### DIFF
--- a/meh/handler.py
+++ b/meh/handler.py
@@ -20,7 +20,14 @@ from meh import MAIN_RESPONSE_DEBUG, MAIN_RESPONSE_SAVE, MAIN_RESPONSE_SHELL, MA
 import bdb
 import os
 import sys
-import report
+
+LIBREPORT_AVAILABLE = False
+try:
+    import report
+    LIBREPORT_AVAILABLE = True
+except ImportError:
+    print("python-meh: libreport is not available in this environment - bug reporting disabled", file=sys.stderr)
+
 import traceback
 import subprocess
 

--- a/meh/ui/text.py
+++ b/meh/ui/text.py
@@ -21,9 +21,16 @@ from __future__ import print_function
 
 from meh import MAIN_RESPONSE_DEBUG, MAIN_RESPONSE_SAVE, MAIN_RESPONSE_SHELL, MAIN_RESPONSE_QUIT
 from meh.ui import AbstractIntf, AbstractSaveExceptionWindow, AbstractMainExceptionWindow, AbstractMessageWindow
-import report
-import report.io.TextIO
-from report import LIBREPORT_WAIT, LIBREPORT_RUN_CLI
+
+
+LIBREPORT_AVAILABLE = False
+try:
+    import report
+    import report.io.TextIO
+    from report import LIBREPORT_WAIT, LIBREPORT_RUN_CLI
+    LIBREPORT_AVAILABLE = True
+except ImportError:
+    print("libreport is not available in this environment - bug reporting disabled")
 
 import os
 import sys
@@ -158,14 +165,17 @@ class MainExceptionWindow(TextWindow, AbstractMainExceptionWindow):
         TextWindow.__init__(self, _("An unknown error has occurred"),
                             *args, **kwargs)
         self._short_traceback = shortTraceback
-        self._menu_items = [(_("Report Bug"), MAIN_RESPONSE_SAVE),
-                            (_("Run shell"), MAIN_RESPONSE_SHELL),
+        self._menu_items = [(_("Run shell"), MAIN_RESPONSE_SHELL),
                             (_("Quit"), MAIN_RESPONSE_QUIT)]
 
         allowDebug = kwargs.get("allowDebug", sys.stdout.isatty)
 
         if allowDebug and allowDebug():
             self._menu_items.insert(1, (_("Debug"), MAIN_RESPONSE_DEBUG))
+
+        # only enable error reporting if libreport is available
+        if LIBREPORT_AVAILABLE:
+            self._menu_items.insert(0, (_("Report Bug"), MAIN_RESPONSE_SAVE))
 
     def run(self, *args, **kwargs):
         self.print_header()

--- a/python-meh.spec
+++ b/python-meh.spec
@@ -18,13 +18,14 @@ BuildArch: noarch
 BuildRequires: make
 BuildRequires: gettext
 BuildRequires: intltool
+%if 0%{?rhel} < 10 || 0%{?fedora}
 BuildRequires: libreport-gtk >= %{libreportver}
 BuildRequires: libreport-cli >= %{libreportver}
-
+BuildRequires: python3-libreport >= %{libreportver}
+%endif
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python3-dbus
-BuildRequires: python3-libreport >= %{libreportver}
 
 %global _description\
 The python-meh package is a python library for handling, saving, and reporting \
@@ -40,8 +41,10 @@ Obsoletes: python2-meh < 0.46-1
 Requires: python3
 Requires: python3-dbus
 Requires: python3-rpm
+%if 0%{?rhel} < 10 || 0%{?fedora}
 Requires: libreport-cli >= %{libreportver}
 Requires: python3-libreport >= %{libreportver}
+%endif
 
 %description -n python3-meh
 The python3-meh package is a python 3 library for handling, saving, and reporting
@@ -54,7 +57,9 @@ Obsoletes: python-meh-gui < 0.46-1
 Obsoletes: python2-meh-gui < 0.46-1
 Requires: python3-meh = %{version}-%{release}
 Requires: python3-gobject, gtk3
+%if 0%{?rhel} < 10 || 0%{?fedora}
 Requires: libreport-gtk >= %{libreportver}
+%endif
 
 %description -n python3-meh-gui
 The python3-meh-gui package provides a GUI for the python3-meh library.

--- a/ui/exception-dialog.glade
+++ b/ui/exception-dialog.glade
@@ -66,8 +66,7 @@
             <property name="valign">start</property>
             <property name="margin_left">40</property>
             <property name="margin_right">40</property>
-            <property name="label" translatable="yes">This program has encountered an unknown error. You may
-report the bug below or quit the program.</property>
+            <property name="label">""</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Make the libreport dependency optional, so that python-meh can run also in environments where libreport is not available.

**TODO:**

- [x] check this actually works on a boot iso without libreport